### PR TITLE
Analyse and plan for new inference providers

### DIFF
--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -47,6 +47,9 @@ export const PROVIDER_FALLBACK_ORDER = [
   "openai",
   "anthropic",
   "google-genai",
+  "moonshot-ai",
+  "deepseek",
+  "qwen",
 ] as const;
 export type Provider = (typeof PROVIDER_FALLBACK_ORDER)[number];
 
@@ -82,6 +85,12 @@ const providerToApiKey = (
       return apiKeys.anthropicApiKey;
     case "google-genai":
       return apiKeys.googleApiKey;
+    case "moonshot-ai":
+      return apiKeys.moonshotApiKey;
+    case "deepseek":
+      return apiKeys.deepseekApiKey;
+    case "qwen":
+      return apiKeys.qwenApiKey;
     default:
       throw new Error(`Unknown provider: ${providerName}`);
   }
@@ -366,6 +375,27 @@ export class ModelManager {
         [LLMTask.REVIEWER]: "o3",
         [LLMTask.ROUTER]: "gpt-4o-mini",
         [LLMTask.SUMMARIZER]: "gpt-4.1-mini",
+      },
+      "moonshot-ai": {
+        [LLMTask.PLANNER]: "kimi-k2-0711-preview",
+        [LLMTask.PROGRAMMER]: "kimi-k2-0711-preview",
+        [LLMTask.REVIEWER]: "kimi-k2-0711-preview",
+        [LLMTask.ROUTER]: "kimi-k2-0711-preview",
+        [LLMTask.SUMMARIZER]: "kimi-k2-0711-preview",
+      },
+      deepseek: {
+        [LLMTask.PLANNER]: "deepseek-reasoner",
+        [LLMTask.PROGRAMMER]: "deepseek-chat",
+        [LLMTask.REVIEWER]: "deepseek-chat",
+        [LLMTask.ROUTER]: "deepseek-chat",
+        [LLMTask.SUMMARIZER]: "deepseek-chat",
+      },
+      qwen: {
+        [LLMTask.PLANNER]: "qwen-plus",
+        [LLMTask.PROGRAMMER]: "qwen3-coder-plus",
+        [LLMTask.REVIEWER]: "qwen-plus",
+        [LLMTask.ROUTER]: "qwen-plus",
+        [LLMTask.SUMMARIZER]: "qwen-plus",
       },
     };
 

--- a/apps/web/src/features/settings-page/api-keys.tsx
+++ b/apps/web/src/features/settings-page/api-keys.tsx
@@ -43,6 +43,9 @@ const API_KEY_DEFINITIONS = {
     { id: "anthropicApiKey", name: "Anthropic" },
     { id: "openaiApiKey", name: "OpenAI" },
     { id: "googleApiKey", name: "Google Gen AI" },
+    { id: "moonshotApiKey", name: "MoonshotAI" },
+    { id: "deepseekApiKey", name: "DeepSeek" },
+    { id: "qwenApiKey", name: "Qwen (Alibaba Cloud)" },
   ],
   // infrastructure: [
   //   {

--- a/apps/web/src/lib/api-keys.ts
+++ b/apps/web/src/lib/api-keys.ts
@@ -16,7 +16,10 @@ export function hasApiKeySet(config: Record<string, any>) {
   if (
     (enabledProviders.includes("anthropic") && !apiKeys.anthropicApiKey) ||
     (enabledProviders.includes("openai") && !apiKeys.openaiApiKey) ||
-    (enabledProviders.includes("google-genai") && !apiKeys.googleApiKey)
+    (enabledProviders.includes("google-genai") && !apiKeys.googleApiKey) ||
+    (enabledProviders.includes("moonshot-ai") && !apiKeys.moonshotApiKey) ||
+    (enabledProviders.includes("deepseek") && !apiKeys.deepseekApiKey) ||
+    (enabledProviders.includes("qwen") && !apiKeys.qwenApiKey)
   ) {
     return false;
   }

--- a/packages/shared/src/open-swe/models.ts
+++ b/packages/shared/src/open-swe/models.ts
@@ -72,6 +72,29 @@ export const MODEL_OPTIONS = [
     label: "Gemini 2.5 Flash",
     value: "google-genai:gemini-2.5-flash",
   },
+  // MoonshotAI models
+  {
+    label: "Kimi K2 Preview",
+    value: "moonshot-ai:kimi-k2-0711-preview",
+  },
+  // DeepSeek models
+  {
+    label: "DeepSeek R1 (Reasoner)",
+    value: "deepseek:deepseek-reasoner",
+  },
+  {
+    label: "DeepSeek V3 (Chat)",
+    value: "deepseek:deepseek-chat",
+  },
+  // Qwen models
+  {
+    label: "Qwen Plus",
+    value: "qwen:qwen-plus",
+  },
+  {
+    label: "Qwen3 Coder Plus",
+    value: "qwen:qwen3-coder-plus",
+  },
 ];
 
 export const MODEL_OPTIONS_NO_THINKING = MODEL_OPTIONS.filter(


### PR DESCRIPTION
Add MoonshotAI, DeepSeek, and Qwen as new inference providers to expand model options and optimize for cost and task-specific performance.

This implementation is minimal, leveraging the existing OpenAI-compatible API integration and requiring only configuration changes to the provider management, model options, and API key handling.

---
<a href="https://cursor.com/background-agent?bcId=bc-5c45a11f-8f7a-4c95-8d64-4f6252f5091b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5c45a11f-8f7a-4c95-8d64-4f6252f5091b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new AI providers: MoonshotAI, DeepSeek, and Qwen (Alibaba Cloud).
  * Introduced new model options for MoonshotAI, DeepSeek, and Qwen, available for selection.
  * Added fields for entering API keys for MoonshotAI, DeepSeek, and Qwen in the settings page.

* **Bug Fixes**
  * Ensured proper validation for the presence of required API keys when enabling the new providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->