### PR TITLE
Update deepseek moonshot qwen for openai provider

### DIFF
--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -75,14 +75,17 @@ const MAX_RETRIES = 3;
 const THINKING_BUDGET_TOKENS = 5000;
 
 // Helper function to get base URL for OpenAI-compatible providers
-const getProviderBaseUrl = (provider: Provider): string | undefined => {
+const getProviderBaseUrl = (provider: Provider, graphConfig?: GraphConfig): string | undefined => {
   switch (provider) {
     case "deepseek":
       return "https://api.deepseek.com/v1";
     case "moonshot-ai":
       return "https://api.moonshot.cn/v1";
     case "qwen":
-      return "https://dashscope.aliyuncs.com/v1";
+      // Allow override via environment variable or GraphConfig for flexibility
+      return process.env.QWEN_BASE_URL || 
+             graphConfig?.configurable?.qwenBaseUrl || 
+             "https://dashscope.aliyuncs.com/compatible-mode/v1"; // Updated for China region compatibility
     default:
       return undefined;
   }
@@ -125,6 +128,34 @@ const providerToApiKey = (
 export class ModelManager {
   private config: ModelManagerConfig;
   private circuitBreakers: Map<string, CircuitBreakerState> = new Map();
+  // WeakMap to track original providers for model instances to prevent provider confusion
+  private originalProviders: WeakMap<ConfigurableModel, Provider> = new WeakMap();
+
+  /**
+   * Infer the original provider from baseUrl during deserialization
+   */
+  private inferProviderFromBaseUrl(baseUrl?: string): Provider | null {
+    if (!baseUrl) return null;
+    
+    if (baseUrl.includes("api.deepseek.com")) return "deepseek";
+    if (baseUrl.includes("api.moonshot.cn")) return "moonshot-ai";
+    if (baseUrl.includes("dashscope.aliyuncs.com")) return "qwen";
+    
+    return null;
+  }
+
+  /**
+   * Get the original provider for a model instance, with fallback to inference from baseUrl
+   */
+  private getOriginalProvider(model: ConfigurableModel): Provider | null {
+    // First try to get from WeakMap
+    const storedProvider = this.originalProviders.get(model);
+    if (storedProvider) return storedProvider;
+    
+    // Fallback: infer from baseUrl if available in model configuration
+    const baseUrl = model._defaultConfig?.baseUrl;
+    return this.inferProviderFromBaseUrl(baseUrl);
+  }
 
   constructor(config: Partial<ModelManagerConfig> = {}) {
     this.config = { ...DEFAULT_MODEL_MANAGER_CONFIG, ...config };
@@ -213,7 +244,7 @@ export class ModelManager {
 
     const apiKey = this.getUserApiKey(graphConfig, provider);
     const langchainProvider = getLangChainProvider(provider);
-    const baseUrl = getProviderBaseUrl(provider);
+    const baseUrl = getProviderBaseUrl(provider, graphConfig);
 
     const modelOptions: InitChatModelArgs = {
       modelProvider: langchainProvider,
@@ -236,7 +267,12 @@ export class ModelManager {
       baseUrl,
     });
 
-    return await initChatModel(modelName, modelOptions);
+    const model = await initChatModel(modelName, modelOptions);
+    
+    // Store the original provider for this model instance to prevent confusion on re-initialization
+    this.originalProviders.set(model, provider);
+    
+    return model;
   }
 
   public getModelConfigs(
@@ -251,7 +287,9 @@ export class ModelManager {
     let selectedModelConfig: ModelLoadConfig | null = null;
 
     if (defaultConfig) {
-      const provider = defaultConfig.modelProvider as Provider;
+      // Use original provider instead of the potentially mapped "openai" provider
+      const originalProvider = this.getOriginalProvider(selectedModel);
+      const provider = originalProvider || (defaultConfig.modelProvider as Provider);
       const modelName = defaultConfig.model;
 
       if (provider && modelName) {

--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -78,11 +78,11 @@ const THINKING_BUDGET_TOKENS = 5000;
 const getProviderBaseUrl = (provider: Provider): string | undefined => {
   switch (provider) {
     case "deepseek":
-      return "https://api.deepseek.com";
+      return "https://api.deepseek.com/v1";
     case "moonshot-ai":
-      return "https://api.moonshot.cn";
+      return "https://api.moonshot.cn/v1";
     case "qwen":
-      return "https://dashscope.aliyuncs.com";
+      return "https://dashscope.aliyuncs.com/v1";
     default:
       return undefined;
   }

--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -92,7 +92,7 @@ const getProviderBaseUrl = (provider: Provider, graphConfig?: GraphConfig): stri
 };
 
 // Helper function to get the actual provider to use with LangChain
-const getLangChainProvider = (provider: Provider): Provider => {
+const getLangChainProvider = (provider: Provider): "openai" | Provider => {
   switch (provider) {
     case "deepseek":
     case "moonshot-ai":

--- a/apps/open-swe/src/utils/llms/model-manager.ts
+++ b/apps/open-swe/src/utils/llms/model-manager.ts
@@ -89,7 +89,7 @@ const getProviderBaseUrl = (provider: Provider): string | undefined => {
 };
 
 // Helper function to get the actual provider to use with LangChain
-const getLangChainProvider = (provider: Provider): string => {
+const getLangChainProvider = (provider: Provider): Provider => {
   switch (provider) {
     case "deepseek":
     case "moonshot-ai":
@@ -220,7 +220,7 @@ export class ModelManager {
       temperature: thinkingModel ? undefined : temperature,
       max_retries: MAX_RETRIES,
       ...(apiKey ? { apiKey } : {}),
-      ...(baseUrl ? { baseUrl } : {}),
+      ...(baseUrl && langchainProvider === "openai" ? { baseUrl } : {}),
       ...(thinkingModel && provider === "anthropic"
         ? {
             thinking: { budget_tokens: thinkingBudgetTokens, type: "enabled" },
@@ -229,7 +229,7 @@ export class ModelManager {
         : { maxTokens: finalMaxTokens }),
     };
 
-    logger.debug("Initializing model", {
+    logger.info("Initializing model", {
       originalProvider: provider,
       langchainProvider,
       modelName,

--- a/packages/shared/src/open-swe/types.ts
+++ b/packages/shared/src/open-swe/types.ts
@@ -621,6 +621,13 @@ export const GraphConfiguration = z.object({
     metadata: GraphConfigurationMetadata.apiKeys,
   }),
   /**
+   * Custom base URL for Qwen API to override the default China region endpoint.
+   * Allows flexibility for different regions or custom deployments.
+   */
+  qwenBaseUrl: withLangGraph(z.string().optional(), {
+    metadata: { description: "Custom base URL for Qwen API" },
+  }),
+  /**
    * The user's GitHub access token. To be used in requests to get information about the user.
    */
   [GITHUB_TOKEN_COOKIE]: withLangGraph(z.string().optional(), {


### PR DESCRIPTION
Configure DeepSeek, Moonshot, and Qwen models to use the OpenAI provider with custom base URLs, resolving integration issues with LangChain.js.

---
<a href="https://cursor.com/background-agent?bcId=bc-57222c8f-e98d-4196-a7a7-0beedadb33a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57222c8f-e98d-4196-a7a7-0beedadb33a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional OpenAI-compatible providers, enabling broader model integration.
  * Introduced configuration option to specify a custom base URL for the Qwen API, improving flexibility for different regions or deployments.

* **Improvements**
  * Enhanced model initialization to automatically adjust provider identification and connection settings for supported providers.
  * Improved logging to display detailed provider and connection information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->