### PR TITLE
Address reviewer comments and research Qwen endpoints

### DIFF
--- a/apps/open-swe/package.json
+++ b/apps/open-swe/package.json
@@ -28,6 +28,7 @@
     "@langchain/anthropic": "^0.3.26",
     "@langchain/community": "^0.3.47",
     "@langchain/core": "^0.3.65",
+    "@langchain/deepseek": "^0.2.1",
     "@langchain/google-genai": "^0.2.9",
     "@langchain/langgraph": "^0.3.8",
     "@langchain/langgraph-sdk": "^0.0.95",

--- a/packages/shared/src/open-swe/types.ts
+++ b/packages/shared/src/open-swe/types.ts
@@ -454,6 +454,13 @@ export const GraphConfigurationMetadata: {
       type: "hidden",
     },
   },
+  qwenUseInternational: {
+    x_open_swe_ui_config: {
+      type: "checkbox",
+      default: false,
+      description: "Use international Qwen endpoint (dashscope-intl.aliyuncs.com) instead of China region endpoint. Enable this if you're outside of China for better performance.",
+    },
+  },
   [GITHUB_TOKEN_COOKIE]: {
     x_open_swe_ui_config: {
       type: "hidden",
@@ -621,11 +628,12 @@ export const GraphConfiguration = z.object({
     metadata: GraphConfigurationMetadata.apiKeys,
   }),
   /**
-   * Custom base URL for Qwen API to override the default China region endpoint.
-   * Allows flexibility for different regions or custom deployments.
+   * Whether to use the international Qwen endpoint instead of the China region endpoint.
+   * International: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+   * China: https://dashscope.aliyuncs.com/compatible-mode/v1
    */
-  qwenBaseUrl: withLangGraph(z.string().optional(), {
-    metadata: { description: "Custom base URL for Qwen API" },
+  qwenUseInternational: withLangGraph(z.boolean().optional(), {
+    metadata: GraphConfigurationMetadata.qwenUseInternational,
   }),
   /**
    * The user's GitHub access token. To be used in requests to get information about the user.


### PR DESCRIPTION
Refactor Qwen endpoint configuration to use a boolean toggle and integrate DeepSeek with its dedicated LangChain package.

The `qwenBaseUrl` string field was replaced with a `qwenUseInternational` boolean toggle to simplify endpoint selection for users, allowing them to easily switch between international and China region Qwen APIs. This also ensures the configuration follows the `GraphConfigurationMetadata` pattern. DeepSeek now uses its dedicated `@langchain/deepseek` package for a cleaner and more direct integration.

---
<a href="https://cursor.com/background-agent?bcId=bc-e64e6049-3b6c-4490-b538-2623886d60ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e64e6049-3b6c-4490-b538-2623886d60ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

